### PR TITLE
chore(webpack): devServer --open --historyApiFallback

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,7 +12,8 @@ module.exports = {
     filename: 'bundle.js',
   },
   devServer: {
-    contentBase: path.join(__dirname, 'dist'),
+    historyApiFallback: true,
+    open: true,
     port: 3000,
   },
   plugins: [


### PR DESCRIPTION
 - Open browser automatically for faster development
 - Use history api
 - Remove unnecessary contentBase